### PR TITLE
Add Chromium browser support alongside Chrome

### DIFF
--- a/fastcdp/core.py
+++ b/fastcdp/core.py
@@ -43,11 +43,17 @@ def _lower1(s): return s[0].lower() + s[1:]
 def _upper1(s): return s[0].upper() + s[1:]
 
 _chrome_paths = dict(
-    Darwin='Library/Application Support/Google/Chrome/DevToolsActivePort',
-    Linux ='.config/google-chrome/DevToolsActivePort')
+    Darwin=['Library/Application Support/Google/Chrome/DevToolsActivePort',
+            'Library/Application Support/Chromium/DevToolsActivePort'],
+    Linux=['.config/google-chrome/DevToolsActivePort',
+           '.config/chromium/DevToolsActivePort'])
 
 def cdp_conninfo(p=None):
-    if not p: p = (Path.home()/(_chrome_paths.get(platform.system()) or _chrome_paths['Linux'])).read_text()
+    if not p:
+        paths = _chrome_paths.get(platform.system(), _chrome_paths['Linux'])
+        f = first(Path.home()/p for p in paths if (Path.home()/p).exists())
+        if not f: raise FileNotFoundError('No Chrome or Chromium DevToolsActivePort found')
+        p = f.read_text()
     lines = p.strip().split('\n')
     return ''.join(lines[:2])
 

--- a/nbs/00_core.ipynb
+++ b/nbs/00_core.ipynb
@@ -129,11 +129,17 @@
     "def _upper1(s): return s[0].upper() + s[1:]\n",
     "\n",
     "_chrome_paths = dict(\n",
-    "    Darwin='Library/Application Support/Google/Chrome/DevToolsActivePort',\n",
-    "    Linux ='.config/google-chrome/DevToolsActivePort')\n",
+    "    Darwin=['Library/Application Support/Google/Chrome/DevToolsActivePort',\n",
+    "            'Library/Application Support/Chromium/DevToolsActivePort'],\n",
+    "    Linux=['.config/google-chrome/DevToolsActivePort',\n",
+    "           '.config/chromium/DevToolsActivePort'])\n",
     "\n",
     "def cdp_conninfo(p=None):\n",
-    "    if not p: p = (Path.home()/(_chrome_paths.get(platform.system()) or _chrome_paths['Linux'])).read_text()\n",
+    "    if not p:\n",
+    "        paths = _chrome_paths.get(platform.system(), _chrome_paths['Linux'])\n",
+    "        f = first(Path.home()/p for p in paths if (Path.home()/p).exists())\n",
+    "        if not f: raise FileNotFoundError('No Chrome or Chromium DevToolsActivePort found')\n",
+    "        p = f.read_text()\n",
     "    lines = p.strip().split('\\n')\n",
     "    return ''.join(lines[:2])"
    ]
@@ -143,7 +149,7 @@
    "id": "0db846c5",
    "metadata": {},
    "source": [
-    "On MacOS, the connection info is stored in `~/Library/Application Support/Google/Chrome/DevToolsActivePort`."
+    "On MacOS, the connection info is stored in `~/Library/Application Support/Google/Chrome/DevToolsActivePort` (or `~/Library/Application Support/Chromium/DevToolsActivePort` for Chromium)."
    ]
   },
   {


### PR DESCRIPTION
## Changes

Extends browser detection to support both Google Chrome and Chromium browsers on macOS and Linux.

### Details

- Updated `_chrome_paths` to include Chromium `DevToolsActivePort` paths for both Darwin and Linux
- `cdp_conninfo()` now iterates available paths and uses the first existing one
- Raises a descriptive `FileNotFoundError` if neither Chrome nor Chromium is found