### PR TITLE
Handle missing page bodies in wait_for_text

### DIFF
--- a/fastcdp/core.py
+++ b/fastcdp/core.py
@@ -894,7 +894,7 @@ async def wait_for_text(self:CDP,
     timeout:int=10, # Seconds to wait before raising
 ):
     "Wait for `text` to appear in (or, with `present=False`, disappear from) the page body or one element"
-    src = f'(document.querySelector({json.dumps(sel)})?.textContent ?? "")' if sel else 'document.body.innerText'
+    src = f'(document.querySelector({json.dumps(sel)})?.textContent ?? "")' if sel else '(document.body?.innerText ?? "")'
     expr = f'{src}.includes({json.dumps(text)})'
     return await self.wait_for(expr if present else f'!({expr})', sid, timeout)
 

--- a/nbs/00_core.ipynb
+++ b/nbs/00_core.ipynb
@@ -2444,7 +2444,7 @@
     "    timeout:int=10, # Seconds to wait before raising\n",
     "):\n",
     "    \"Wait for `text` to appear in (or, with `present=False`, disappear from) the page body or one element\"\n",
-    "    src = f'(document.querySelector({json.dumps(sel)})?.textContent ?? \"\")' if sel else 'document.body.innerText'\n",
+    "    src = f'(document.querySelector({json.dumps(sel)})?.textContent ?? \"\")' if sel else '(document.body?.innerText ?? \"\")'\n",
     "    expr = f'{src}.includes({json.dumps(text)})'\n",
     "    return await self.wait_for(expr if present else f'!({expr})', sid, timeout)"
    ]


### PR DESCRIPTION
Treat a temporarily missing document body as empty text while waiting. This
keeps wait_for_text polling during navigation instead of raising a JavaScript
error before the new page creates its body.

Update both the notebook source and exported module.